### PR TITLE
v0.2.1 (#294)

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,11 +1,14 @@
 import launch
 import sys
-from importlib_metadata import version
 
 python = sys.executable
 
 
 def install():
+    if not launch.is_installed("importlib_metadata"):
+        launch.run_pip("install importlib_metadata", "importlib_metadata", live=True)
+    from importlib_metadata import version
+
     if launch.is_installed("tensorrt"):
         if not version("tensorrt") == "9.0.1.post11.dev4":
             launch.run(

--- a/scripts/trt.py
+++ b/scripts/trt.py
@@ -299,7 +299,7 @@ class TensorRTScript(scripts.Script):
         if self.torch_unet:
             return super().process_batch(p, *args, **kwargs)
 
-        if self.idx != sd_unet.current_unet.profile_idx:
+        if sd_unet.current_unet is not None and self.idx != sd_unet.current_unet.profile_idx:
             sd_unet.current_unet.profile_idx = self.idx
             sd_unet.current_unet.switch_engine()
 

--- a/ui_trt.py
+++ b/ui_trt.py
@@ -268,7 +268,10 @@ def get_lora_checkpoints():
         if os.path.exists(config_file):
             with open(config_file, "r") as f:
                 config = json.load(f)
-            version = SDVersion.from_str(config["sd version"])
+            try:
+                version = SDVersion.from_str(config["sd version"])
+            except:
+                version = SDVersion.Unknown
 
         else:
             version = SDVersion.Unknown


### PR DESCRIPTION
* fix typo (#79)

* Faster and simplified install

* Print correct profile when engine is loaded

* Use scripts callbacks

* increase max resolution

* adding native LoRA support, avoiding model.py import error and some refactoring

* more refactoring and added typing

* Enable torch fallback

* update inastall

* change default XL engine

* cc independent lora

* Update Instrucitons

* Fix for #225 Install.py silently blocked by blocking call of nvidia-cudnn-cu11 uninstall due to interactive python shell opening (#226)

* v0.2.0 (#217)

* fix typo (#79)

* Print correct profile when engine is loaded

* Use scripts callbacks

* increase max resolution

* adding native LoRA support, avoiding model.py import error and some refactoring

* more refactoring and added typing

* Enable torch fallback

* update inastall

* change default XL engine

* cc independent lora

* Update Instrucitons

---------



* Fix subprocess blocking issue when installing

---------




* Resolve AttributeError on generation without Unet (#224)

* v0.2.0 (#217)

* fix typo (#79)

* Print correct profile when engine is loaded

* Use scripts callbacks

* increase max resolution

* adding native LoRA support, avoiding model.py import error and some refactoring

* more refactoring and added typing

* Enable torch fallback

* update inastall

* change default XL engine

* cc independent lora

* Update Instrucitons

---------



* Resolve AttributeError on generation without Unet

---------




* Fixes crashes cause by lora checkpoint configs missing sd version (#251)

During the initial Lora loading process, if a config for a specified **.safetensor** file does not contain the property **"sd version"**, the plugin crashes and does not show the trt tab. 

fixes the issue by inferencing the model version as unknown

* Fix AttributeError when accessing profile_idx of NoneType (#259)

* fix #157

---------